### PR TITLE
Avoid matching lines without escapes that start with the letter 'm'.

### DIFF
--- a/spec/javascripts/ansi_stream_spec.coffee
+++ b/spec/javascripts/ansi_stream_spec.coffee
@@ -7,9 +7,10 @@ describe "AnsiStream", ->
     expect(span.className.indexOf(color)).toBeGreaterThan(-1)
 
   it 'returns uncolorized spans if there are no escape codes', ->
-    span = stream.process("toto").childNodes[0]
+    span = stream.process("mkdir").childNodes[0]
     expectClass(span, 'ansi-background-default')
     expectClass(span, 'ansi-foreground-default')
+    expect(span.innerHTML).toBe('mkdir')
 
   it 'returns colorized spans if there is an foreground color code', ->
     expectClass(stream.process('\u001B[31mtoto').childNodes[0], 'ansi-foreground-red')
@@ -35,4 +36,3 @@ describe "AnsiStream", ->
     spans = stream.process("\u001B[4mtoto\u001B[24mtiti")
     expectClass(spans.childNodes[0], 'ansi-underline')
     expect(spans.childNodes[1].className.indexOf('ansi-underline')).toBe(-1)
-

--- a/vendor/assets/javascripts/ansi_stream.coffee
+++ b/vendor/assets/javascripts/ansi_stream.coffee
@@ -5,9 +5,10 @@ class @AnsiStream
 
   process: (text) ->
     parts = text.split(/\033\[/)
-    parts = parts.filter (part) -> part
 
     spans = document.createDocumentFragment()
+    first_part = parts.shift()
+    spans.appendChild(@span.create(first_part, @style)) if first_part
     for part in parts
       [partText, styles] = @_extractTextAndStyles(part)
       @style.apply(styles)
@@ -17,7 +18,7 @@ class @AnsiStream
     spans
 
   _extractTextAndStyles: (originalText) ->
-    matches = originalText.match(/^([\d;]*)m([^]*)$/m)
+    matches = originalText.match(/^([\d;]*)m([^]*)$/)
 
     return [originalText, null] unless matches
 


### PR DESCRIPTION
## Problem

When a stream of text is processed with no escapes, then a match will be made on any lines that start with the letter `m`.  E.g. 

```
preceding text
mkdir:
cannot create directory `data`: Permission denied
```

will get converted into

```
kdir:
cannot create directory `data`: Permission denied
```

where everything before "\nm" is removed from the text.

This is happening because
- ansi control sequences are detected by splitting on the escape characters `"\e["` then all lines are treated as if they are preceded by these characters, even the first line which should never be considered to start with a control sequence
- the regexp to match the style control sequence uses the `m` flag, which causes the `^` to match the start of the line rather than just the start of the string
## Solution
- Remove the first part after splitting the string by the escape characters to avoid treating it like anything other than plain text.
- Remove the `m` flag from the regexp
