### PR TITLE
Workaround new version of coffeescript forbidding octal in Regexes

### DIFF
--- a/vendor/assets/javascripts/ansi_stream.coffee
+++ b/vendor/assets/javascripts/ansi_stream.coffee
@@ -4,7 +4,7 @@ class @AnsiStream
     @span = new AnsiSpan()
 
   process: (text) ->
-    parts = text.split(/\033\[/)
+    parts = text.split(`/\033\[/`)
 
     spans = document.createDocumentFragment()
     first_part = parts.shift()


### PR DESCRIPTION
Upstream change: https://github.com/jashkenas/coffeescript/pull/3833


@gmalette 
