### PR TITLE
Use textContent instead of innerHTML for both speed and safety

### DIFF
--- a/spec/javascripts/ansi_stream_spec.coffee
+++ b/spec/javascripts/ansi_stream_spec.coffee
@@ -12,6 +12,11 @@ describe "AnsiStream", ->
     expectClass(span, 'ansi-foreground-default')
     expect(span.innerHTML).toBe('mkdir')
 
+
+  it 'is not subject to XSS', ->
+    span = stream.process("echo <script>alert('pwned!')").childNodes[0]
+    expect(span.innerHTML).toBe("echo &lt;script&gt;alert('pwned!')")
+
   it 'returns colorized spans if there is an foreground color code', ->
     expectClass(stream.process('\u001B[31mtoto').childNodes[0], 'ansi-foreground-red')
 

--- a/vendor/assets/javascripts/ansi_stream.coffee
+++ b/vendor/assets/javascripts/ansi_stream.coffee
@@ -81,6 +81,6 @@ class AnsiStyle
 class AnsiSpan
   create: (text, style) ->
     span = document.createElement('span')
-    span.innerHTML = text
+    span.textContent = text
     span.className = style.toClass()
     span


### PR DESCRIPTION
Safety: previously we had to do `stream.process(escapeHtml(chunk))` to prevent XSS, it's not required anymore.

Speed: first we save on the script escaping, and second it appear that `textContent` is was faster than `innerHTML`, at least for our use case:

before:
![capture d ecran 2015-04-15 a 14 26 16](https://cloud.githubusercontent.com/assets/44640/7166385/8b5acbd6-e37b-11e4-93fa-34bda7c1fae2.png)

after:
![capture d ecran 2015-04-15 a 14 26 27](https://cloud.githubusercontent.com/assets/44640/7166389/916242d4-e37b-11e4-841f-131a4a91b837.png)

It's basically a 50% speed improvement (your mileage may vary of course).